### PR TITLE
Wait until the page has fully loaded, not just the DOM

### DIFF
--- a/export-private-documentation-to-html.js
+++ b/export-private-documentation-to-html.js
@@ -37,7 +37,7 @@ console.log(url);
 
   console.log("Opening documentation in workspace " + workspaceId + "...");
 
-  await page.goto(url, { waitUntil: 'domcontentloaded' });
+  await page.goto(url, { waitUntil: 'load' });
 
   await page.exposeFunction('saveHtml', (content) => {
     const filename = 'structurizr-' + workspaceId + '-documentation.html';


### PR DESCRIPTION
I found that things like diagrams were not ready when using domcontentloaded and this caused the script to wait forever. It makes sense to wait until it is fully loaded.