### PR TITLE
Fix crash: Export of diagrams in "png" format 

### DIFF
--- a/export-diagrams.js
+++ b/export-diagrams.js
@@ -128,8 +128,8 @@ var actualNumberOfExports = 0;
         browser.close();
       }    
     } else {
-      const diagramFilename = FILENAME_SUFFIX + view.key + '.png';
-      const diagramKeyFilename = FILENAME_SUFFIX + view.key + '-key.png'
+      const diagramFilename = view.key + '.png';
+      const diagramKeyFilename = view.key + '-key.png'
 
       page.evaluate((diagramFilename) => {
         structurizr.scripting.exportCurrentDiagramToPNG({ includeMetadata: true, crop: false }, function(png) {


### PR DESCRIPTION
The branch exporting diagrams with the `png` option was accessing an undeclared constant `FILENAME_SUFFIX`. 
Removed those lines - like it was done for the `svg` option.
